### PR TITLE
Added: check if the user who used the interaction owns the bot

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -4,6 +4,16 @@ const config = require("../config.js");
 const rest = new REST({ version: "10" }).setToken(config.token);
 
 module.exports.run = async (inter, client, guild) => {
+  // only the user/team owners of the bot can use 'add'
+  const team  = await client.application.fetch();
+  // even if this command is added as global
+  if (!team.owner.members.get(inter.user.id)
+    && team.owner.id != inter.user.id ) {
+    return inter.reply({
+      content: "` add `: you don't have ` owner ` permission",
+      ephemeral: true,
+    });
+  }
   // get the input (command name)
   const name = inter.options.getString("name").toUpperCase();
   // get the type of the command guild/global

--- a/commands/add.js
+++ b/commands/add.js
@@ -5,7 +5,7 @@ const rest = new REST({ version: "10" }).setToken(config.token);
 
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'add'
-  const team  = await client.application.fetch();
+  const team = await client.application.fetch();
   // even if this command is added as global
   if (!team.owner.members.get(inter.user.id)
     && team.owner.id != inter.user.id ) {

--- a/commands/add.js
+++ b/commands/add.js
@@ -6,9 +6,10 @@ const rest = new REST({ version: "10" }).setToken(config.token);
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'add'
   const team = await client.application.fetch();
+  const isTeam = team.owner.member.get(inter.user.id);
+  const isOwner = team.owner.id == inter.user.id;
   // even if this command is added as global
-  if (!team.owner.members.get(inter.user.id)
-    && team.owner.id != inter.user.id ) {
+  if (!isTeam && !isOwner) {
     return inter.reply({
       content: "` add `: you don't have ` owner ` permission",
       ephemeral: true,

--- a/commands/add.js
+++ b/commands/add.js
@@ -6,8 +6,8 @@ const rest = new REST({ version: "10" }).setToken(config.token);
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'add'
   const bot = await client.application.fetch();
-  const team = bot.owner.members;
   const isOwner = bot.owner.id == inter.user.id;
+  const team = bot.owner.members;
   const isMember = team ? team.get(inter.user.id) : false;
   // even if this command is added as global
   if (!isMember && !isOwner) {

--- a/commands/add.js
+++ b/commands/add.js
@@ -5,11 +5,12 @@ const rest = new REST({ version: "10" }).setToken(config.token);
 
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'add'
-  const team = await client.application.fetch();
-  const isTeam = team.owner.member.get(inter.user.id);
-  const isOwner = team.owner.id == inter.user.id;
+  const bot = await client.application.fetch();
+  const team = bot.owner.members;
+  const isOwner = bot.owner.id == inter.user.id;
+  const isMember = team ? team.get(inter.user.id) : false;
   // even if this command is added as global
-  if (!isTeam && !isOwner) {
+  if (!isMember && !isOwner) {
     return inter.reply({
       content: "` add `: you don't have ` owner ` permission",
       ephemeral: true,

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -3,6 +3,16 @@ const { token } = require("../config.js");
 const rest = new REST({ version: "10" }).setToken(token);
 
 module.exports.run = async (inter, client, guild) => {
+  // only the user/team owners of the bot can use 'add'
+  const team  = await client.application.fetch();
+  // even if this command is added as global
+  if (!team.owner.members.get(inter.user.id)
+    && team.owner.id != inter.user.id ) {
+    return inter.reply({
+      content: "`delete`: you don't have `owner` permission",
+  	  ephemeral: true,
+    });
+  }
   // get the type of the command guild/global
   const type = inter.options.getString("type");
   // get the input (command name)

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -5,9 +5,10 @@ const rest = new REST({ version: "10" }).setToken(token);
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'delete'
   const team = await client.application.fetch();
+  const isOwner = team.owner.id == inter.user.id;
+  const isTeam = team.owner.members.get(inter.user.id);
   // even if this command is added as global
-  if (!team.owner.members.get(inter.user.id) &&
-    team.owner.id != inter.user.id) {
+  if (!isOwner && !isTeam) {
     return inter.reply({
       content: "` delete `: you don't have ` owner ` permission",
       ephemeral: true,

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -4,11 +4,12 @@ const rest = new REST({ version: "10" }).setToken(token);
 
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'delete'
-  const team = await client.application.fetch();
-  const isOwner = team.owner.id == inter.user.id;
-  const isTeam = team.owner.members.get(inter.user.id);
+  const bot = await client.application.fetch();
+  const team = bot.owner.members;
+  const isMember = team ? team.get(inter.user.id) : false;
+  const isOwner = bot.owner.id == inter.user.id;
   // even if this command is added as global
-  if (!isOwner && !isTeam) {
+  if (!isOwner && !isMember) {
     return inter.reply({
       content: "` delete `: you don't have ` owner ` permission",
       ephemeral: true,

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -4,13 +4,13 @@ const rest = new REST({ version: "10" }).setToken(token);
 
 module.exports.run = async (inter, client, guild) => {
   // only the user/team owners of the bot can use 'delete'
-  const team  = await client.application.fetch();
+  const team = await client.application.fetch();
   // even if this command is added as global
-  if (!team.owner.members.get(inter.user.id)
-    && team.owner.id != inter.user.id ) {
+  if (!team.owner.members.get(inter.user.id) &&
+    team.owner.id != inter.user.id) {
     return inter.reply({
       content: "` delete `: you don't have ` owner ` permission",
-  	  ephemeral: true,
+      ephemeral: true,
     });
   }
   // get the type of the command guild/global

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -3,13 +3,13 @@ const { token } = require("../config.js");
 const rest = new REST({ version: "10" }).setToken(token);
 
 module.exports.run = async (inter, client, guild) => {
-  // only the user/team owners of the bot can use 'add'
+  // only the user/team owners of the bot can use 'delete'
   const team  = await client.application.fetch();
   // even if this command is added as global
   if (!team.owner.members.get(inter.user.id)
     && team.owner.id != inter.user.id ) {
     return inter.reply({
-      content: "`delete`: you don't have `owner` permission",
+      content: "` delete `: you don't have ` owner ` permission",
   	  ephemeral: true,
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slash-bot-template",
-  "version": "2.10.1",
+  "version": "2.15.0",
   "description": "A template discord bot with slash commands",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The bot will check if the interaction user is the owner or is in a team that owns the bot. The `add` and `delete` commands will only work for the bot's owner, even if he is on another server where the owner doesn't have administrator permissions, and those commands were defined globally.

Reference: https://github.com/GuriZenit/slash-bot-template/issues/14#issuecomment-1327800692